### PR TITLE
Clytwynec/develop

### DIFF
--- a/pa11ycrawler/cmdline.py
+++ b/pa11ycrawler/cmdline.py
@@ -18,6 +18,9 @@ from pa11ycrawler.settings_helpers import (
 from pa11ycrawler.spiders.pa11y_spider import Pa11ySpider
 
 
+log = logging.getLogger(__name__)
+
+
 # ------------ Main CLI ------------
 
 
@@ -101,7 +104,7 @@ def run(settings):
     """
     Runs the pa11ycrawler.
     """
-    print 'Running pa11ycrawler...'
+    log.info('Running pa11ycrawler...')
     process = CrawlerProcess(settings)
     process.crawl(Pa11ySpider)
     process.start()  # this will block until crawling is finished
@@ -149,7 +152,7 @@ def gen_html_reports(settings):
     """
     Generates html reports from the 1.0-json formatted reports.
     """
-    print "Generating html reports..."
+    log.info('Generating html reports...')
     reporter = HtmlReporter(settings)
     reporter.make_html()
 
@@ -202,7 +205,7 @@ def main():
     args = parser.parse_args()
     settings = args_to_settings(args)
     logging.basicConfig(
-        format='%(asctime)s [%(levelname)s] [%(name)s]: %(message)s"',
+        format='%(asctime)s [%(levelname)s] [%(name)s]: %(message)s',
         level=settings.get('LOG_LEVEL')
     )
     args.func(settings)

--- a/pa11ycrawler/cmdline.py
+++ b/pa11ycrawler/cmdline.py
@@ -3,6 +3,7 @@
 The command line interface for pa11ycrawler.
 """
 import argparse
+import logging
 
 from textwrap import dedent
 
@@ -15,6 +16,7 @@ from pa11ycrawler.settings_helpers import (
     get_default_settings,
 )
 from pa11ycrawler.spiders.pa11y_spider import Pa11ySpider
+
 
 # ------------ Main CLI ------------
 
@@ -133,6 +135,7 @@ def json_to_html_cli(subparsers):
     keys = [
         'PA11YCRAWLER_REPORTS_DIR',
         'PA11YCRAWLER_KEEP_EXISTING_REPORTS',
+        'LOG_LEVEL',
     ]
 
     for key in keys:
@@ -198,6 +201,10 @@ def main():
     parser = cli()
     args = parser.parse_args()
     settings = args_to_settings(args)
+    logging.basicConfig(
+        format='%(asctime)s [%(levelname)s] [%(name)s]: %(message)s"',
+        level=settings.get('LOG_LEVEL')
+    )
     args.func(settings)
 
 

--- a/pa11ycrawler/reporter.py
+++ b/pa11ycrawler/reporter.py
@@ -30,7 +30,7 @@ def get_code_info(code):
     base_code_matches = guide_pattern.match(code)
 
     if not base_code_matches:
-        print (
+        log.debug(
             'Code {code} doesn\'t match expected pattern. Unable to produce '
             'documentation links for reports.'.format(code=code)
         )

--- a/pa11ycrawler/templates/index.html
+++ b/pa11ycrawler/templates/index.html
@@ -1,7 +1,8 @@
 <%inherit file="base.html" />
 <%namespace name="summary" file="summary.html"/>
 <div class="col-sm-10 col-sm-offset-1">
-<h1>Accessibility Audit Index</h1>
+<h1>Accessibility Audit Index</h1> <br />
+<a href="summary_by_code.html">View summary by error code</a>
 </div>
 ${summary.make_summary(
     count['error'],

--- a/pa11ycrawler/templates/result.html
+++ b/pa11ycrawler/templates/result.html
@@ -31,15 +31,15 @@
         </thead>
         <tbody>
         % for result in report['results']:
-            ${makerow(result, classes)}
+            ${makerow(result, color_classes)}
         % endfor
         </tbody>
     </table>
 </div>
 
-<%def name="makerow(result, classes)">
+<%def name="makerow(result, color_classes)">
     <tr>
-        <td class="${classes[result['type']]}">${result['type']}</td>
+        <td class="${color_classes[result['type']]}">${result['type']}</td>
         <td> ${get_code_info(result['code'])['base_code']} </td>
         <td>
         % for code, href in get_code_info(result['code'])['doc_links'].iteritems():

--- a/pa11ycrawler/templates/summary_by_code.html
+++ b/pa11ycrawler/templates/summary_by_code.html
@@ -12,7 +12,7 @@ ${summary.make_summary_toolbar(
     counts_by_type['error'],
     counts_by_type['warning'],
     counts_by_type['notice'],
-    total_codes,
+    counts_by_type['total'],
 )}
 
 <br />

--- a/pa11ycrawler/templates/summary_by_code.html
+++ b/pa11ycrawler/templates/summary_by_code.html
@@ -1,0 +1,56 @@
+<%inherit file="base.html" />
+<%namespace name="summary" file="summary.html"/>
+<div class="col-sm-2 col-sm-offset-10" style="padding-top: 10px;">
+    <a href="index.html">Back to Index</a>
+</div>
+
+<div class="col-sm-10 col-sm-offset-1">
+<h1>Accessibility Audit Summary by Code</h1>
+</div>
+
+${summary.make_summary_toolbar(
+    counts_by_type['error'],
+    counts_by_type['warning'],
+    counts_by_type['notice'],
+    total_codes,
+)}
+
+<br />
+<div class="col-sm-10 col-sm-offset-1" style="margin-bottom: 30px;">
+<table data-classes='table table-no-bordered'
+    data-toggle="table"
+    data-search="true">
+    <thead>
+        <tr>
+            <th data-field='Type' data-sortable="true">Type</th>
+            <th data-field='Code' data-sortable="true">Results Link</th>
+            <th data-field='Message' data-sortable="true">Message</th>
+            <th data-field='Pages Affected'>Pages Affected</th>
+            <th data-field='Docs' data-sortable="true">Docs</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for code,result in results.iteritems():
+            ${makerow(code, result, color_classes)}
+        % endfor
+    </tbody>
+</table>
+</div>
+
+<%def name="makerow(code, result, color_classes)">
+    <tr>
+        <td class="${color_classes[result['type']]}">${result['type']}</td>
+        <td> ${get_code_info(code)['base_code']} </td>
+        <td> ${result['message']} </td>
+        <td>
+            % for page in result['pages']:
+                <a href="${page[1]}">${page[0]}</a><br />
+            % endfor
+        </td>
+        <td>
+        % for sub_code, href in get_code_info(code)['doc_links'].iteritems():
+            <a href="${href}"><span class='sr-only'>Docs for </span>${sub_code}</a>
+        % endfor
+        </td>
+    </tr>
+</%def>

--- a/pa11ycrawler/tests/test_reporter.py
+++ b/pa11ycrawler/tests/test_reporter.py
@@ -150,6 +150,7 @@ class HtmlReporterTestCase(TestCase):
             results_map_file.write(results_map)
 
         self.html_results_file = os.path.join(self.reporter.html_dir, '1234.html')
+        self.html_summary_by_code_file = os.path.join(self.reporter.html_dir, 'summary_by_code.html')
         self.html_index_file = os.path.join(self.reporter.html_dir, 'index.html')
 
         self.addCleanup(self.cleanup)
@@ -161,3 +162,4 @@ class HtmlReporterTestCase(TestCase):
         self.reporter.make_html()
         self.assertTrue(os.path.isfile(self.html_results_file))
         self.assertTrue(os.path.isfile(self.html_index_file))
+        self.assertTrue(os.path.isfile(self.html_summary_by_code_file))

--- a/pa11ycrawler/tests/test_reporter.py
+++ b/pa11ycrawler/tests/test_reporter.py
@@ -160,6 +160,51 @@ class HtmlReporterTestCase(TestCase):
 
     def test_make_html(self):
         self.reporter.make_html()
+        expected_summary = {
+            'pageResults': {
+                'http://example.com': {
+                    'notice': 2,
+                    'warning': 0,
+                    'page_title': 'test',
+                    'error': 1,
+                    'total': 3,
+                    'filename': '1234',
+                },
+            },
+            'overallCount': {
+                'notice': 2,
+                'total': 3,
+                'warning': 0,
+                'pages_affected': 1,
+                'error': 1,
+            },
+        }
+        self.assertEqual(expected_summary, self.reporter.summary)
+
+        expected_summary_by_code = {
+            'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81': {
+                'message': 'msg2',
+                'type': 'error',
+                'pages': set([('test', 'http://example.com')]),
+            },
+            'unknownpattern_for_code': {
+                'message': 'msg4',
+                'type': 'notice',
+                'pages': set([('test', 'http://example.com')]),
+            },
+            'WCAG2AA.Principle1.Guideline1_1.1_1_1.G94.Image': {
+                'message': 'msg3',
+                'type': 'notice',
+                'pages': set([('test', 'http://example.com')]),
+            },
+            'WCAG2AA.Principle3.Guideline3_2.3_2_1.G107': {
+                'message': 'msg1',
+                'type': 'notice',
+                'pages': set([('test', 'http://example.com')]),
+            },
+        }
+        self.assertEqual(expected_summary_by_code, self.reporter.summary_by_code)
+
         self.assertTrue(os.path.isfile(self.html_results_file))
         self.assertTrue(os.path.isfile(self.html_index_file))
         self.assertTrue(os.path.isfile(self.html_summary_by_code_file))

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+coverage==4.0.3
 edx-lint==0.5.1
 freezegun==0.3.6
 nose==1.3.7


### PR DESCRIPTION
This PR Does two things:
1.  Adds a summary of the results based on error code (maps error code to pages that have that error).  Previously, there was only a summary base one pages (maps page to all the errors on it).
2. Uses logging module instead of print statements for more robust logging.  This updated some of the existing print statements to debug/info level logs and adds a few more details.  For reference, these log changes are meant to be able to be consumed easily by Splunk.

@benpatterson @jzoldak  Please review.
