### PR TITLE
Make scrapy follow the logging level specified

### DIFF
--- a/pa11ycrawler/cmdline.py
+++ b/pa11ycrawler/cmdline.py
@@ -8,6 +8,7 @@ import logging
 from textwrap import dedent
 
 from scrapy.crawler import CrawlerProcess
+from scrapy.utils.log import configure_logging
 
 from pa11ycrawler.reporter import HtmlReporter
 from pa11ycrawler.settings_helpers import (
@@ -204,9 +205,13 @@ def main():
     parser = cli()
     args = parser.parse_args()
     settings = args_to_settings(args)
+    configure_logging({
+        'LOG_FORMAT': '%(asctime)s [%(levelname)s] [%(name)s]: %(message)s',
+        'LOG_LEVEL': settings.get('LOG_LEVEL'),
+    })
     logging.basicConfig(
         format='%(asctime)s [%(levelname)s] [%(name)s]: %(message)s',
-        level=settings.get('LOG_LEVEL')
+        level=settings.get('LOG_LEVEL'),
     )
     args.func(settings)
 

--- a/pa11ycrawler/cmdline.py
+++ b/pa11ycrawler/cmdline.py
@@ -105,6 +105,10 @@ def run(settings):
     """
     Runs the pa11ycrawler.
     """
+    configure_logging({
+        'LOG_FORMAT': settings.get('LOG_FORMAT'),
+        'LOG_LEVEL': settings.get('LOG_LEVEL'),
+    }, install_root_handler=False)
     log.info('Running pa11ycrawler...')
     process = CrawlerProcess(settings)
     process.crawl(Pa11ySpider)
@@ -153,6 +157,10 @@ def gen_html_reports(settings):
     """
     Generates html reports from the 1.0-json formatted reports.
     """
+    logging.basicConfig(
+        format=settings.get('LOG_FORMAT'),
+        level=settings.get('LOG_LEVEL'),
+    )
     log.info('Generating html reports...')
     reporter = HtmlReporter(settings)
     reporter.make_html()
@@ -205,14 +213,6 @@ def main():
     parser = cli()
     args = parser.parse_args()
     settings = args_to_settings(args)
-    configure_logging({
-        'LOG_FORMAT': '%(asctime)s [%(levelname)s] [%(name)s]: %(message)s',
-        'LOG_LEVEL': settings.get('LOG_LEVEL'),
-    })
-    logging.basicConfig(
-        format='%(asctime)s [%(levelname)s] [%(name)s]: %(message)s',
-        level=settings.get('LOG_LEVEL'),
-    )
     args.func(settings)
 
 

--- a/pa11ycrawler/settings.py
+++ b/pa11ycrawler/settings.py
@@ -89,6 +89,7 @@ COOKIES_DEBUG = False
 COOKIES_ENABLED = True
 DEPTH_LIMIT = 2
 LOG_LEVEL = 'INFO'
+LOG_FORMAT = '%(asctime)s [%(levelname)s] [%(name)s]: %(message)s'
 
 # Don't override these or the crawler will surely break --------
 BOT_NAME = 'pa11ycrawler'


### PR DESCRIPTION
The `LOG_LEVEL` setting wasn't being followed when running Scrapy.  It looks like it broke when I added the updated logging for the reporter.  Fixed by following Scrapy docs below.

Docs: http://doc.scrapy.org/en/latest/topics/logging.html#module-scrapy.utils.log
Example logs can be found here: https://test-jenkins.testeng.edx.org/job/edx-platform-accessibility-master/31/

@benpatterson @jzoldak  Please review.
