### PR TITLE
Log JSON decode error instead of erroring

### DIFF
--- a/pa11ycrawler/reporter.py
+++ b/pa11ycrawler/reporter.py
@@ -209,7 +209,11 @@ class HtmlReporter(ReporterBaseClass):
             result_file = os.path.join(self.results_dir, info['filename'] + '.1.0.json')
 
             with open(result_file, 'r') as report:
-                results = json.load(report)
+                try:
+                    results = json.load(report)
+                except ValueError as error:
+                    log.error(error.message)
+                    continue
 
             self._make_page_result_html(url, info, results)
             self._update_summary(url, info, results)


### PR DESCRIPTION
@benpatterson @jzoldak  Please review.

When I turned the crawler on on master branch builds for platform, it errored out reading one of the report files. I wasn't able to reproduce the issue on test-jenkins, but reproduced it in a test by creating an empty file.   My assumption is that the specific file causing trouble on the platform build is either empty or has a bad character.  It wasn't archived unfortunately, but with this change I can investigate further without having failed builds.
