### PR TITLE
Correct pa11y config file format

### DIFF
--- a/pa11ycrawler/spiders/edx.py
+++ b/pa11ycrawler/spiders/edx.py
@@ -85,9 +85,17 @@ class EdxSpider(CrawlSpider):
         @scrapes url request_headers accessed_at page_title
         """
         title = response.xpath("//title/text()").extract_first().strip()
+        # `response.request.headers` is a dictionary where the key is the
+        # header name, and the value is a *list*, containing one item,
+        # which is the header value. We need to get rid of this list, and just
+        # have key-value pairs. (This list probably exists in case the same
+        # header is sent multiple times, but that's not happening in this case,
+        # and the list construct is getting in the way.)
+        request_headers = {key: value[0] for key, value
+                           in response.request.headers.items()}
         item = A11yItem(
             url=response.url,
-            request_headers=response.request.headers,
+            request_headers=request_headers,
             accessed_at=datetime.utcnow(),
             page_title=title,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mako>=1.0.2
 scrapy>=1.0.5
 urlobject
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mako>=1.0.2
-scrapy>=1.0.5
-urlobject
-lxml
+mako==1.0.4
+scrapy==1.1.1
+urlobject<3.0
+lxml<4.0


### PR DESCRIPTION
Pa11y wants request headers to be a simple key-value dictionary, while Scrapy was outputting a dictionary where the values were lists of strings. This commit corrects this, and also adds a test
to detect when `<title>` elements mismatch between pa11y and scrapy, which is how we identified this bug in the first place.
