### PR TITLE
Re-add extra globbing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
     version='1.1.0',
     package_data={
         'pa11ycrawler': [
-            'templates/*',
-            'templates/assets/js/*',
-            'templates/assets/css/*',
+            'templates/*.*',
+            'templates/assets/js/*.*',
+            'templates/assets/css/*.*',
         ]
     },
     packages=[


### PR DESCRIPTION
Turns out this is necessary in order to install this package via `pip install git+https://`. I have no idea why.
