### PR TITLE
Specify email password

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,18 @@ Option       | Default                        | Example
 ------------ | ------------------------------ | -------
 `domain`     | `localhost`                    | `scrapy crawl edx -a domain=edx.org`
 `port`       | `8000`                         | `scrapy crawl edx -a port=8003`
+`email`      | None                           | `scrapy crawl edx -a email=staff@example.com -a password=edx`
+`password`   | None                           | (see above)
 `course_key` | `course-v1:edX+Test101+course` | `scrapy crawl edx -a course_key=org/course/run`
 `data_dir`   | `data`                         | `scrapy crawl edx -a data_dir=~/pa11y-data`
 
 These options can be combined by specifying the `-a` flag multiple times.
 For example, `scrapy crawl edx -a domain=courses.edx.org -a port=80`.
+
+If an email and password are not specified, then pa11ycrawler will use the
+"auto auth" feature in Open edX to create a staff user, and crawl as that user.
+Note that this assumes that the "auto auth" feature is enabled -- if not, the
+crawler won't be able to crawl without an email and password set.
 
 The `data_dir` option is used to determine where this crawler will save its
 output. pa11ycrawler will run each page of the site through `pa11y`,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 pytest>=2.7
 pytest-mock
+freezegun==0.3.7
 pycodestyle
 edx-lint==0.5.1
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scrapy==1.1.1
+scrapy==1.1.2
 mako<2.0
 urlobject<3.0
 lxml<4.0

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -1,0 +1,104 @@
+import pytest
+import json
+from datetime import datetime
+import scrapy
+from scrapy.http.response.text import TextResponse
+import textwrap
+from freezegun import freeze_time
+from pa11ycrawler.spiders.edx import EdxSpider
+
+
+def test_start_with_api():
+    spider = EdxSpider(email="staff@example.com", password="edx")
+    requests = list(spider.start_requests())
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, scrapy.Request)
+    expected_url = 'http://localhost:8000/api/courses/v1/blocks?course_id=course-v1%3AedX%2BTest101%2Bcourse&depth=all&all_blocks=true'
+    assert request.url == expected_url
+    assert request.method == "GET"
+    assert request.headers == {}
+    assert not request.callback
+
+
+def test_start_with_auto_auth():
+    spider = EdxSpider(email=None, password=None)
+    requests = list(spider.start_requests())
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, scrapy.Request)
+    expected_url = 'http://localhost:8000/auto_auth?course_id=course-v1%3AedX%2BTest101%2Bcourse&staff=true'
+    assert request.url == expected_url
+    assert request.method == "GET"
+    assert request.headers == {"Accept": ["application/json"]}
+    # this is to verify that the JSON response will get handled in a callback
+    assert request.callback
+
+
+def test_auto_auth_response(mocker):
+    spider = EdxSpider(email=None, password=None)
+    fake_result = {
+        "email": "sparky@gooddog.woof",
+        "password": "b4rkb4rkwo0f",
+    }
+    fake_response = mocker.Mock(body=json.dumps(fake_result))
+
+    assert spider.login_email == None
+    assert spider.login_password == None
+    requests = list(spider.parse_auto_auth(fake_response))
+    assert spider.login_email == "sparky@gooddog.woof"
+    assert spider.login_password == "b4rkb4rkwo0f"
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, scrapy.Request)
+    expected_url = 'http://localhost:8000/api/courses/v1/blocks?course_id=course-v1%3AedX%2BTest101%2Bcourse&depth=all&all_blocks=true'
+    assert request.url == expected_url
+    assert request.method == "GET"
+    assert request.headers == {}
+    assert not request.callback
+
+
+@freeze_time("2016-01-01")
+def test_log_back_in(mocker):
+    login_html = textwrap.dedent("""
+    <html>
+      <head>
+        <title>Sign in or Register</title>
+      </head>
+      <body>
+        <h1>Sign In</h1>
+        <form id="login">
+          <input name="email">
+          <input name="password">
+          <input type="checkbox" name="remember">
+        </form>
+        <button>Create an account</button>
+      </body>
+    </html>
+    """)
+    fake_request = scrapy.Request(
+        url="http://localhost:8000/foo/bar"
+    )
+    fake_response = TextResponse(
+        url="http://localhost:8000/login?next=/foo/bar",
+        request=fake_request,
+        body=login_html,
+        encoding="utf-8",
+    )
+    spider = EdxSpider(email="abc@def.com", password="xyz")
+
+    requests = list(spider.parse_item(fake_response))
+
+    assert len(requests) == 2
+    request = requests[0]
+    item = requests[1]
+    expected_url = 'http://localhost:8000/login?next=/foo/bar&password=xyz&email=abc%40def.com'
+    assert request.url == expected_url
+    assert item == {
+        'accessed_at': datetime(2016, 1, 1),
+        'page_title': 'Sign in or Register',
+        'request_headers': {},
+        'url': 'http://localhost:8000/login?next=/foo/bar',
+    }
+


### PR DESCRIPTION
This allows the person calling pa11ycrawler to specify an email and password to use when logging into the Open edX installation. If the email and password aren't specified, pa11ycrawler will attempt to create a user via the "auto auth" feature, and save the email and password for that user.

In addition, if (when) the crawler gets logged out, it can now automatically log back in using the same email and password. If it obtained an email and password from the "auto auth" feature, it
will save those credentials and use them to log back in automatically.

@benpatterson, can you review this? (Or delegate someone else to do so.)
