### PR TITLE
Change HTML report link order

### DIFF
--- a/pa11ycrawler/templates/index.html
+++ b/pa11ycrawler/templates/index.html
@@ -36,8 +36,8 @@ ${summary.make_summary(
 
 <%def name="makerow(page)">
     <tr>
-        <td><a href="${page['filename']}">${page['page_title']}</a></td>
-        <td><a href="${page['url']}">
+        <td><a href="${page['filename']}" target="_blank">${page['page_title']}</a></td>
+        <td><a href="${page['url']}" target="_blank">
           View <span class='sr-only'>${page['page_title']}&nbsp;</span>Live
         </a></td>
         <td>${page['count']['total']}</td>

--- a/pa11ycrawler/templates/index.html
+++ b/pa11ycrawler/templates/index.html
@@ -37,7 +37,9 @@ ${summary.make_summary(
 <%def name="makerow(page)">
     <tr>
         <td><a href="${page['filename']}">${page['page_title']}</a></td>
-        <td><a href="${page['url']}">View Live</a></td>
+        <td><a href="${page['url']}">
+          View <span class='sr-only'>${page['page_title']}&nbsp;</span>Live
+        </a></td>
         <td>${page['count']['total']}</td>
         <td>${page['count']['error']}</td>
         <td>${page['count']['warning']}</td>

--- a/pa11ycrawler/templates/index.html
+++ b/pa11ycrawler/templates/index.html
@@ -18,8 +18,8 @@ ${summary.make_summary(
     data-search="true">
     <thead>
         <tr>
-            <th data-field='Page Title' data-sortable="true">Page Title</th>
-            <th data-field='Results Link' data-sortable="true">Results Link</th>
+            <th data-field='Page' data-sortable="true">Page</th>
+            <th data-field='View Live' data-sortable="true">View Live</th>
             <th class='active' data-field='Total' data-sortable="true">Total</th>
             <th class='danger' data-field='Errors' data-sortable="true">Errors</th>
             <th class='warning' data-field='Warnings' data-sortable="true">Warnings</th>
@@ -36,8 +36,8 @@ ${summary.make_summary(
 
 <%def name="makerow(page)">
     <tr>
-        <td><a href="${page['url']}">${page['page_title']}</a></td>
-        <td><a href="${page['filename']}">Results<span class='sr-only'>&nbsp;for ${page['page_title']}</span></a></td>
+        <td><a href="${page['filename']}">${page['page_title']}</a></td>
+        <td><a href="${page['url']}">View Live</a></td>
         <td>${page['count']['total']}</td>
         <td>${page['count']['error']}</td>
         <td>${page['count']['warning']}</td>


### PR DESCRIPTION
Previously, in the HTML report, the page title was linked to the live URL of the page, and there was a "Results" link to the page results. With this commit, these links are swapped: the page title is linked to the page results, and there is a "View Live" link to the live URL.

@cptvitamin, just want to verify that this is what you want.
