### PR TITLE
Track pa11y values

### DIFF
--- a/pa11ycrawler/pipelines.py
+++ b/pa11ycrawler/pipelines.py
@@ -109,20 +109,17 @@ class Pa11yPipeline(object):
         config_file.close()
         return config_file
 
-    def check_title_match(self, expected_title, pa11y_output, logger):
+    def check_title_match(self, expected_title, pa11y_results, logger):
         """
         Check if Scrapy reports any issue with the HTML <title> element.
         If so, compare that <title> element to the title that we got in the
         A11yItem. If they don't match, something is screwy, and pa11y isn't
         parsing the page that we expect.
         """
-        if not pa11y_output:
+        if not pa11y_results:
             # no output from pa11y, nothing to check.
             return
-        pa11y_results = json.loads(pa11y_output.decode('utf8')).get("results")
-        if not pa11y_results:
-            return
-        title_errs = [err for err in pa11y_results
+        title_errs = [err for err in pa11y_results.get("results", [])
                       if err["html"].startswith("<title")]
         for err in title_errs:
             title_elmt = html.fragment_fromstring(err["html"])
@@ -147,15 +144,12 @@ class Pa11yPipeline(object):
                 )
                 logger.error(msg)
 
-    def write_pa11y_results(self, item, pa11y_output, data_dir):
+    def write_pa11y_results(self, item, pa11y_results, data_dir):
         """
-        Write the output from pa11y into a data file. Note that `pa11y_output`
-        is a bytes object, not a string -- it comes directly from the
-        subprocess module.
+        Write the output from pa11y into a data file.
         """
         # `pa11y` outputs JSON, so we'll just add a bit more info for context
-        data = json.loads(pa11y_output.decode('utf8'))
-        data.update(item)
+        pa11y_results.update(item)
 
         # it would be nice to use the URL as the filename,
         # but that gets complicated (long URLs, special characters, etc)
@@ -173,7 +167,7 @@ class Pa11yPipeline(object):
             os.makedirs(data_dir)
 
         with open(filepath, 'w') as f:
-            json.dump(data, f, cls=DateTimeEncoder)
+            json.dump(pa11y_results, f, cls=DateTimeEncoder)
 
     def process_item(self, item, spider):
         """
@@ -223,7 +217,11 @@ class Pa11yPipeline(object):
                 )
             )
 
-        self.check_title_match(item['page_title'], stdout, spider.logger)
+        if stdout:
+            pa11y_results = json.loads(stdout.decode('utf8'))
+        else:
+            pa11y_results = {}
+        self.check_title_match(item['page_title'], pa11y_results, spider.logger)
         os.remove(config_file.name)
-        self.write_pa11y_results(item, stdout, spider.data_dir)
+        self.write_pa11y_results(item, pa11y_results, spider.data_dir)
         return item


### PR DESCRIPTION
Fixes #21. With this change, the ending output from the crawler looks something like this:

```
2016-08-26 16:12:07 [INFO] [scrapy]: Crawled 18 pages (at 1 pages/min), scraped 14 items (at 4 items/min)
2016-08-26 16:12:07 [INFO] [scrapy]: Dumping Scrapy stats:
{'downloader/request_bytes': 27294,
 'downloader/request_count': 38,
 'downloader/request_method_count/GET': 38,
 'downloader/response_bytes': 2900404,
 'downloader/response_count': 38,
 'downloader/response_status_count/200': 18,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/302': 19,
 'dupefilter/filtered': 1333,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2016, 8, 26, 20, 12, 7, 473494),
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 14,
 'log_count/ERROR': 13,
 'log_count/INFO': 31,
 'log_count/WARNING': 2,
 'offsite/domains': 6,
 'offsite/filtered': 77,
 'pa11y/error': 80,
 'pa11y/notice': 2729,
 'pa11y/warning': 895,
 'request_depth_max': 3,
 'response_received_count': 18,
 'scheduler/dequeued': 38,
 'scheduler/dequeued/memory': 38,
 'scheduler/enqueued': 391,
 'scheduler/enqueued/memory': 391,
 'start_time': datetime.datetime(2016, 8, 26, 20, 8, 5, 347198)}
2016-08-26 16:12:07 [INFO] [scrapy]: Spider closed (shutdown)
```

Notice the `pa11y/error`, `pa11y/warning`, and `pa11y/notice` keys. This is useful for Splunk tracking.
