### PR TITLE
pa11y-reporter-json-oldnode

### DIFF
--- a/pa11ycrawler/pipelines.py
+++ b/pa11ycrawler/pipelines.py
@@ -67,7 +67,7 @@ class Pa11yPipeline(object):
     """
     pa11y_path = "node_modules/.bin/pa11y"
     cli_flags = {
-        "reporter": "json",
+        "reporter": "json-oldnode",
     }
 
     def __init__(self):

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "pa11y": "4.0.1",
+    "pa11y-reporter-json-oldnode": "1.0.0",
     "bootstrap": "3.3.7",
     "bootstrap-table": "1.11.0",
     "jquery": "3.1.0"

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -118,7 +118,7 @@ def test_pa11y_happy_path(mocker, tmpdir):
     # pa11y should be called correctly
     mock_Popen.assert_called_with(
         ["node_modules/.bin/pa11y", "http://courses.edx.org/fakepage",
-         "--config=mockconfig.json", "--reporter=json"],
+         "--config=mockconfig.json", "--reporter=json-oldnode"],
         shell=False, stdout=sp.PIPE, stderr=sp.PIPE
     )
 


### PR DESCRIPTION
Because we still want the new JSON reporter format, but with compatibility with old versions of Node.js. Project is here: https://github.com/singingwolfboy/pa11y-reporter-json-oldnode
