### PR TITLE
Deal with unicode errors.

### DIFF
--- a/pa11ycrawler/html.py
+++ b/pa11ycrawler/html.py
@@ -106,7 +106,7 @@ def render_html(data_dir, output_dir):
         # replace `.json` with `.html`
         fname = data_file.namebase + ".html"
         html_path = output_dir / fname
-        html_path.write_text(rendered_html)
+        html_path.write_text(rendered_html, encoding='utf-8')
 
         data["filename"] = fname
         pages.append(data)


### PR DESCRIPTION
Example traceback this attempts to solve:

```
Traceback (most recent call last):
   File "/home/jenkins/edx-venv/bin/pa11ycrawler-html", line 9, in <module>
     load_entry_point('pa11ycrawler==1.4.0', 'console_scripts', 'pa11ycrawler-html')()
   File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/pa11ycrawler/html.py", line 61, in main
     return render_html(data_dir, output_dir)
   File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/pa11ycrawler/html.py", line 109, in render_html
     html_path.write_text(rendered_html)
   File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/path.py", line 864, in write_text
     text = text.encode(encoding or sys.getdefaultencoding(), errors)
 UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 149660: ordinal not in range(128)
```
