### PR TITLE
rules for ignoring pa11y results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,17 @@ scrapy crawl edx
 There are several options for this spider that you can configure using the
 `-a` scrapy flag.
 
-Option       | Default                        | Example
------------- | ------------------------------ | -------
-`domain`     | `localhost`                    | `scrapy crawl edx -a domain=edx.org`
-`port`       | `8000`                         | `scrapy crawl edx -a port=8003`
-`email`      | None                           | `scrapy crawl edx -a email=staff@example.com -a password=edx`
-`password`   | None                           | (see above)
-`http_user`  | None                           | `scrapy crawl edx -a http_user=grace -a http_pass=hopper`
-`http_pass`  | None                           | (see above)
-`course_key` | `course-v1:edX+Test101+course` | `scrapy crawl edx -a course_key=org/course/run`
-`data_dir`   | `data`                         | `scrapy crawl edx -a data_dir=~/pa11y-data`
+Option                   | Default                        | Example
+------------------------ | ------------------------------ | -------
+`domain`                 | `localhost`                    | `scrapy crawl edx -a domain=edx.org`
+`port`                   | `8000`                         | `scrapy crawl edx -a port=8003`
+`email`                  | None                           | `scrapy crawl edx -a email=staff@example.com -a password=edx`
+`password`               | None                           | (see above)
+`http_user`              | None                           | `scrapy crawl edx -a http_user=grace -a http_pass=hopper`
+`http_pass`              | None                           | (see above)
+`course_key`             | `course-v1:edX+Test101+course` | `scrapy crawl edx -a course_key=org/course/run`
+`pa11y_ignore_rules_url` | None                           | `scrapy crawl edx -a pa11y_ignore_rules_url=https://...`
+`data_dir`               | `data`                         | `scrapy crawl edx -a data_dir=~/pa11y-data`
 
 These options can be combined by specifying the `-a` flag multiple times.
 For example, `scrapy crawl edx -a domain=courses.edx.org -a port=80`.
@@ -49,6 +50,10 @@ crawler won't be able to crawl without an email and password set.
 
 The `http_user` and `http_pass` arguments are used for HTTP Basic Auth. If
 either of these is unset, pa11ycrawler will not attempt to use HTTP Basic auth.
+
+The `pa11y_ignore_rules_url` arguments allow you to specify the URL to a
+YAML file of pa11y ignore rules. These rules are used to indicate that certain
+output from pa11y has been manually checked, and can be safely ignored.
 
 The `data_dir` option is used to determine where this crawler will save its
 output. pa11ycrawler will run each page of the site through `pa11y`,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Jinja2<3.0
 urlobject<3.0
 lxml<4.0
 path.py<9.0
+requests<3.0
+pyyaml<4.0


### PR DESCRIPTION
This pull request adds a new feature: you can now specify a URL that points to a YAML file with ignore rules for the pa11ycrawler. The rules will look like this:

``` yaml
"/":
  - message: "Duplicate id attribute *"
  - message: "Check that the title element describes the document."
"/*/about":
  - message: "* contrast ratio between the text and * background *"
"/dontcare":
  - type: notice
```

In this example, pa11ycrawler will ignore messages about duplicate id attributes and the `<title>` element on the root page of the website. On all "about" pages, it will ignore messages about contrast ratios. And on the `/dontcare` page, it will ignore any output that is of type "notice" (but still report warnings and errors).

We will need a separate repository for this YAML file, which I've created here: https://github.com/singingwolfboy/pa11ycrawler-ignore. It currently has one rule in it, suggested by @cptvitamin. More rules can be added, and this repo can be moved to the [`edx` organization on GitHub](https://github.com/edx). To test the crawler using this ruleset, you can run:

```
$ scrapy crawl edx -a port=8003 -a pa11y_ignore_rules_url=https://raw.githubusercontent.com/singingwolfboy/pa11ycrawler-ignore/master/ignore.yaml
```
