### PR TITLE
Truncate more when ellipsis found.

### DIFF
--- a/pa11ycrawler/pipelines/pa11y.py
+++ b/pa11ycrawler/pipelines/pa11y.py
@@ -107,7 +107,7 @@ def check_title_match(expected_title, pa11y_results, logger):
         # content we can from the output
         elided_title = title_elmt.text.strip()
         if elided_title.endswith("..."):
-            pa11y_title = elided_title[0:-3]
+            pa11y_title = elided_title[0:-4]
         else:
             pa11y_title = elided_title
 


### PR DESCRIPTION
Previously the following scenario would be considered a title mismatch:
- scrapy found "This is a page"
- pa11y found "This is a page ..."

The extra space character would result in a mismatch when accommodating the
ellipsis. This change truncates the title farther in order to handle this scenario.
