### PR TITLE
encode title comparison string to prevent unicode errors (AC-692)

### DIFF
--- a/pa11ycrawler/pipelines/pa11y.py
+++ b/pa11ycrawler/pipelines/pa11y.py
@@ -116,7 +116,7 @@ def check_title_match(expected_title, pa11y_results, logger):
         if pa11y_title not in expected_title:
             # whoa, something's screwy!
             msg = (
-                'Parser mismatch! '
+                u'Parser mismatch! '
                 'Scrapy saw full title "{scrapy_title}", '
                 'Pa11y saw elided title "{elided_title}".'
             ).format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-scrapy==1.1.2
 Jinja2<3.0
-urlobject<3.0
 lxml<4.0
 path.py<9.0
-requests<3.0
 pyyaml<4.0
+requests<3.0
+scrapy==1.1.2
+urlobject<3.0

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 import json
 from datetime import datetime
@@ -195,7 +196,7 @@ def test_pa11y_not_installed(mocker):
 def test_pa11y_title_mismatch(mocker, tmpdir):
     item = {
         "url": "http://courses.edx.org/ponies",
-        "page_title": "Sparkly Ponies of Joy",
+        "page_title": u"Sparkly Ponies of Joy ☃",
         "request_headers": {"Cookie": "nocookieforyou"},
         "accessed_at": datetime(2016, 8, 20, 14, 12, 45),
     }
@@ -234,7 +235,7 @@ def test_pa11y_title_mismatch(mocker, tmpdir):
 
     # check
     expected_msg = (
-        'Parser mismatch! Scrapy saw full title "Sparkly Ponies of Joy", '
+        u'Parser mismatch! Scrapy saw full title "Sparkly Ponies of Joy ☃", '
         'Pa11y saw elided title "Evil Demons of Despa...".'
     )
     spider.logger.error.assert_called_with(expected_msg)


### PR DESCRIPTION
Fixes an issue (https://openedx.atlassian.net/browse/AC-692) where the crawler chokes on page titles that contain unicode characters.

@jzoldak can you review please?

[This Jenkins run against platform](https://build.testeng.edx.org/job/edx-platform-accessibility-pr/29116/console) shows pa11ycrawler running *without* the unicode errors!