### PR TITLE
add a failable "scrapy test" command

### DIFF
--- a/pa11ycrawler/commands/test.py
+++ b/pa11ycrawler/commands/test.py
@@ -1,0 +1,25 @@
+from scrapy.commands.crawl import Command as ExistingCrawlCommand
+from scrapy.exceptions import UsageError
+from pa11ycrawler.spiders.edx import EdxSpider
+
+class Command(ExistingCrawlCommand):
+
+    requires_project = True
+
+    def short_desc(self):
+        return 'Run a spider that fails on specified errors'
+
+    def run(self, args, opts):
+        if len(args) < 1:
+            raise UsageError()
+        elif len(args) > 1:
+            raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
+        spname = args[0]
+
+        self.crawler_process.crawl(spname, **opts.spargs)
+        crawler = list(self.crawler_process.crawlers)[0]
+        self.crawler_process.start()
+
+        for setting in crawler.settings['FAILURE_CATEGORIES']:
+            if crawler.stats.get_value(setting, 0) > 0:
+                self.exitcode = 1

--- a/pa11ycrawler/commands/test.py
+++ b/pa11ycrawler/commands/test.py
@@ -1,9 +1,16 @@
+"""
+Contains the scrapy test command for configurable process failures.
+"""
 from scrapy.commands.crawl import Command as ExistingCrawlCommand
 from scrapy.exceptions import UsageError
-from pa11ycrawler.spiders.edx import EdxSpider
+
 
 class Command(ExistingCrawlCommand):
-
+    """
+    A wrapper for scrapy crawl that assigns the process a nonzero exit code if
+    any errors are raised during execution. Error categories are configurable
+    via settings['FAILURE_CATEGORIES'].
+    """
     requires_project = True
 
     def short_desc(self):

--- a/pa11ycrawler/commands/test.py
+++ b/pa11ycrawler/commands/test.py
@@ -36,6 +36,6 @@ class Command(ScrapyCommand):
         self.existing_crawl_command.run(args, opts)
 
         for setting in crawler.settings['FAILURE_CATEGORIES']:
-            if crawler.stats.get_value(setting, 0) > 0:
+            if crawler.stats.get_value(setting, 0):
                 self.exitcode = 1
                 break

--- a/pa11ycrawler/settings.py
+++ b/pa11ycrawler/settings.py
@@ -31,3 +31,10 @@ COOKIES_ENABLED = True
 DEPTH_LIMIT = 6
 LOG_LEVEL = 'INFO'
 LOG_FORMAT = '%(asctime)s [%(levelname)s] [%(name)s]: %(message)s'
+LOG_STDOUT = True
+
+# Error catching
+COMMANDS_MODULE = 'pa11ycrawler.commands'
+FAILURE_CATEGORIES = [
+    'log_count/ERROR',
+]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,109 @@
+import pytest
+from optparse import OptionParser
+from scrapy.crawler import CrawlerRunner
+from scrapy.statscollectors import MemoryStatsCollector
+
+
+@pytest.fixture
+def mock_runner(mocker):
+    """
+    Return a function that builds a mock CrawlerRunner for use in testing
+    scrapy commands.
+    """
+    def build_mock_runner(stats_value):
+        """
+        Return a mock CrawlerRunner containing a mocked Crawler instance.
+        This Crawler's stats object will return the given stats_value for
+        any queried stat.
+        """
+        CrawlCommandMock = mocker.patch('scrapy.commands.crawl.Command')
+
+        StatsMock = mocker.patch('scrapy.statscollectors.MemoryStatsCollector')
+        stats_instance = StatsMock.return_value
+        stats_instance.get_value.return_value = stats_value
+
+        CrawlerMock = mocker.patch('scrapy.crawler.Crawler')
+        crawler_instance = CrawlerMock()
+        settings = mocker.PropertyMock(return_value='foo')
+        type(crawler_instance).settings = {
+            'FAILURE_CATEGORIES': [
+                'foo/ERROR',
+                'bar/WARNING'
+            ]
+        }
+        type(crawler_instance).stats = stats_instance
+
+        RunnerMock = mocker.patch('scrapy.crawler.CrawlerRunner')
+        runner_instance = RunnerMock()
+        runner_instance.create_crawler.return_value = crawler_instance
+
+        return runner_instance
+
+    return build_mock_runner
+
+def test_run_pass(mock_runner):
+    """
+    Simulate a test run with no errors and ensure the process exits with
+    the proper exitcode.
+    """
+    runner_instance = mock_runner(stats_value=None)
+
+    # we have to import TestCommand here rather than globally, to avoid
+    # conflicting with the mocked scrapy.commands.crawl.Command
+    from pa11ycrawler.commands.test import Command as TestCommand
+    tc = TestCommand()
+    tc.crawler_process = runner_instance
+    tc.run(['edx'], {})
+    assert tc.exitcode == 0
+
+def test_run_failure(mock_runner):
+    """
+    Simulate a test run that yields a nonzero error stat count and ensure
+    the process exits with the proper exitcode.
+    """
+    runner_instance = mock_runner(stats_value=3)
+
+    from pa11ycrawler.commands.test import Command as TestCommand
+    tc = TestCommand()
+    tc.crawler_process = runner_instance
+    tc.run(['edx'], {})
+    assert tc.exitcode == 1
+
+def test_passthrough_add_options_called(mocker):
+    """
+    Ensure that the test command passes through its add_options call
+    to scrapy.commands.crawl.Command.
+    """
+    CrawlCommandMock = mocker.patch('scrapy.commands.crawl.Command')
+    crawl_instance = CrawlCommandMock()
+    add_options_spy = mocker.spy(crawl_instance, 'add_options')
+
+    from pa11ycrawler.commands.test import Command as TestCommand
+    tc = TestCommand()
+
+    tc.existing_crawl_command = crawl_instance
+    fake_parser = OptionParser()
+    tc.add_options(fake_parser)
+
+    assert crawl_instance.add_options.call_count == 1
+    add_options_spy.assert_called_with(fake_parser)
+
+def test_passthrough_process_options_called(mocker):
+    """
+    Ensure that the test command passes through its process_options call
+    to scrapy.commands.crawl.Command.
+    """
+    CrawlCommandMock = mocker.patch('scrapy.commands.crawl.Command')
+    crawl_instance = CrawlCommandMock()
+    process_options_spy = mocker.spy(crawl_instance, 'process_options')
+
+    from pa11ycrawler.commands.test import Command as TestCommand
+    tc = TestCommand()
+
+    tc.existing_crawl_command = crawl_instance
+    fake_args = {'foo': 'bar'}
+    fake_opts = ['baz', 'quux']
+    tc.process_options(fake_args, fake_opts)
+
+    assert crawl_instance.process_options.call_count == 1
+    process_options_spy.assert_called_with(fake_args, fake_opts)


### PR DESCRIPTION
### What

Add a new scrapy command `test` that essentially does the same thing as `crawl`, but assigns the process a nonzero exit code if any errors are raised during its execution. The stats failure categories are configurable via `FAILURE_CATEGORIES` in the project settings. We may also want to extend this command in the future to write junit-ish error reports as well.

### Why

By design, scrapy crawl is bulletproof; it will never fail due to execution errors (one of the maintainers discusses why in [this thread](https://github.com/scrapy/scrapy/issues/1231)). Unlike the typical scrapy project, however, pa11ycrawler crawls a codebase we maintain. If it errors at all, it means something is wrong either in edx-platform or in pa11ycrawler -- we want to know about this so we can fix it.

### Additional Changes

To extend this functionality to edx-platform, we'll need to run `scrapy test` instead of `scrapy crawl` in the paver pa11ycrawler process [as shown here](https://github.com/edx/edx-platform/pull/14210/files#diff-24f8ae1c1dc88adba0fa547cea3b5e50R401). We should hold off on doing this until we're sure it won't start erroneously failing builds.