### PR TITLE
dedupe sequence start pages

### DIFF
--- a/pa11ycrawler/pipelines/__init__.py
+++ b/pa11ycrawler/pipelines/__init__.py
@@ -24,11 +24,29 @@ class DuplicatesPipeline(object):
         """
         return URLObject(url).without_query()
 
+    def is_sequence_start_page(self, url):
+        """
+        Does this URL represent the first page in a section sequence? E.g.
+        /courses/{coursename}/courseware/{block_id}/{section_id}/1
+        This will return the same page as the pattern
+        /courses/{coursename}/courseware/{block_id}/{section_id}.
+        """
+        return (
+            len(url.path.segments) == 6 and
+            url.path.segments[0] == 'courses' and
+            url.path.segments[2] == 'courseware' and
+            url.path.segments[5] == '1'
+        )
+
     def process_item(self, item, spider):  # pylint: disable=unused-argument
         """
         Stops processing item if we've already seen this URL before.
         """
         url = self.clean_url(item["url"])
+
+        if self.is_sequence_start_page(url):
+            url = url.parent
+
         if url in self.urls_seen:
             raise DropItem("Dropping duplicate url {url}".format(url=item["url"]))
         else:

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -63,6 +63,34 @@ def test_duplicates_pipeline_querystring():
         dup_pl.process_item(item4, spider)
 
 
+def test_duplicates_pipeline_courseware_start():
+    dup_pl = DuplicatesPipeline()
+    spider = object()
+    item1 = {"url": "https://courses.edx.org/courses/foo/courseware/bar/baz/"}
+    processed1 = dup_pl.process_item(item1, spider)
+    assert item1 == processed1
+
+    item2 = {"url": "https://courses.edx.org/courses/foo/courseware/bar/baz/1"}
+    with pytest.raises(DropItem):
+        dup_pl.process_item(item2, spider)
+
+    item3 = {"url": "https://courses.edx.org/courses/foo/courseware/bar/baz/2"}
+    processed3 = dup_pl.process_item(item3, spider)
+    assert item3 == processed3
+
+    item4 = {"url": "https://courses.edx.org/courses/quux/courseware/bar/baz/1"}
+    processed4 = dup_pl.process_item(item4, spider)
+    assert item4 == processed4
+
+    item5 = {"url": "https://courses.edx.org/courses/quux/courseware/bar/baz/"}
+    with pytest.raises(DropItem):
+        dup_pl.process_item(item5, spider)
+
+    item6 = {"url": "https://courses.edx.org/courses/quux/courseware/bar/baz/6"}
+    processed6 = dup_pl.process_item(item6, spider)
+    assert item6 == processed6
+
+
 def test_drf_pipeline():
     drf_pl = DropDRFPipeline()
     spider = object()


### PR DESCRIPTION
### What
Add a case to the `DuplicatesPipeline` to treat explicit courseware sequence start URLs as equivalent to implicit courseware sequence start URLs. That is:

`/courses/{coursename}/courseware/{block_id}/{section_id}/1`

will be equivalent to

`/courses/{coursename}/courseware/{block_id}/{section_id}/`


### Why
These URL patterns are functionally equivalent and return the same generated page, causing dozens of duplicate pages (and hundreds of duplicate violations) in the crawler results. This change removes a significant amount of noise.