### PR TITLE
bump pip on travis instead of depending on old setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.5"
 install:
+  - pip install --upgrade pip
   - make develop
 script:
   - make quality

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyyaml<4.0
 requests<3.0
 scrapy==1.1.2
 urlobject<3.0
-setuptools==33.1.1


### PR DESCRIPTION
Based on Renzo's suggestion, bump pip on Travis instead of pinning setuptools universally. Seems better to take a more environment-specific approach (also, pinning setuptools caused some difficulties installing pa11ycrawler locally).