### PR TITLE
unique violations

### DIFF
--- a/pa11ycrawler/pipelines/pa11y.py
+++ b/pa11ycrawler/pipelines/pa11y.py
@@ -107,7 +107,7 @@ def check_title_match(expected_title, pa11y_results, logger):
         # content we can from the output
         elided_title = title_elmt.text.strip()
         if elided_title.endswith("..."):
-            pa11y_title = elided_title[0:-4]
+            pa11y_title = elided_title[0:-4].strip()
         else:
             pa11y_title = elided_title
 

--- a/pa11ycrawler/templates/base.html
+++ b/pa11ycrawler/templates/base.html
@@ -45,9 +45,10 @@
                     $('.table').bootstrapTable('filterBy', options);
                     $('.filterby-btn.current').removeClass('current').attr('aria-pressed', 'false');
                     $(this).addClass('current').attr('aria-pressed', 'true');
-                })
+                });
             });
         </script>
+        <title>{% block title %}Audit Results{% endblock %} - pa11ycrawler</title>
     </head>
     <body>
         {% block content %}{% endblock %}

--- a/pa11ycrawler/templates/detail.html
+++ b/pa11ycrawler/templates/detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Results for {{ page_title }}{% endblock %}
 {% block content %}
 <div class="col-sm-2 col-sm-offset-10" style="padding-top: 10px;">
   <a href="index.html">Back to Index</a>

--- a/pa11ycrawler/templates/index.html
+++ b/pa11ycrawler/templates/index.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Results by Page{% endblock %}
 {% block content %}
 <div class="col-sm-10 col-sm-offset-1">
   <h1>Accessibility Audit Index</h1>
@@ -9,58 +10,53 @@
 <div class="col-sm-3 col-sm-offset-1">
   <ul class="list-group">
       <li class="list-group-item">
-          Pages
+          <a href="#pages-checked">Pages</a>
           <span class="badge">{{ pages|length }}</span>
       </li>
       <li class="list-group-item">
-          Errors
+          <a href="errors.html">Errors</a>
           <span class="list-group-item-danger badge">{{ num_error }}</span>
       </li>
       <li class="list-group-item">
-          Warnings
+          <a href="warnings.html">Warnings</a>
           <span class="list-group-item-warning badge">{{ num_warning }}</span>
       </li>
       <li class="list-group-item">
-          Notices
+          <a href="notices.html">Notices</a>
           <span class="list-group-item-info badge">{{ num_notice }}</span>
-      </li>
-      <li class="list-group-item">
-          Total Issues
-          <span class="badge">{{ num_error + num_warning + num_notice }}</span>
       </li>
   </ul>
 </div>
-
 <br />
 <div class="col-sm-10 col-sm-offset-1" style="margin-bottom: 30px;">
-<h2 class="hd-4">Pages Checked</h2>
-<table data-classes='table table-no-bordered'
-       data-toggle="table"
-       data-search="true">
-  <thead>
-    <tr>
-      <th data-field='Page' data-sortable="true">Page</th>
-      <th data-field='View Live' data-sortable="true">View Live</th>
-      <th class='danger' data-field='Errors' data-sortable="true" data-width="10%" data-align="right">Errors</th>
-      <th class='warning' data-field='Warnings' data-sortable="true" data-width="10%" data-align="right">Warnings</th>
-      <th class='info' data-field='Notices' data-sortable="true" data-width="10%" data-align="right">Notices</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for page in pages %}
+  <h2 id="pages-checked" class="hd-4">Pages Checked</h2>
+  <table data-classes='table table-no-bordered'
+         data-toggle="table"
+         data-search="true">
+    <thead>
       <tr>
-        <td><a href="{{ page.filename }}" target="_blank">
-          {{ page.page_title }}
-        </a></td>
-        <td><a href="{{ page.url }}" target="_blank">
-          View <span class='sr-only'>{{ page.page_title }}&nbsp;</span>Live
-        </a></td>
-        <td>{{ page.num_error }}</td>
-        <td>{{ page.num_warning }}</td>
-        <td>{{ page.num_notice }}</td>
+        <th data-field='Page' data-sortable="true">Page</th>
+        <th data-field='View Live' data-sortable="true">View Live</th>
+        <th class='danger' data-field='Errors' data-sortable="true" data-width="10%" data-align="right">Errors</th>
+        <th class='warning' data-field='Warnings' data-sortable="true" data-width="10%" data-align="right">Warnings</th>
+        <th class='info' data-field='Notices' data-sortable="true" data-width="10%" data-align="right">Notices</th>
       </tr>
-    {% endfor %}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {% for page in pages %}
+        <tr>
+          <td><a href="{{ page.filename }}" target="_blank">
+            {{ page.page_title }}
+          </a></td>
+          <td><a href="{{ page.url }}" target="_blank">
+            View <span class='sr-only'>{{ page.page_title }}&nbsp;</span>Live
+          </a></td>
+          <td>{{ page.num_error }}</td>
+          <td>{{ page.num_warning }}</td>
+          <td>{{ page.num_notice }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 </div>
 {% endblock content %}

--- a/pa11ycrawler/templates/unique.html
+++ b/pa11ycrawler/templates/unique.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block title %}Accessibility {{current_type|capitalize}}s{% endblock %}
+{% block content %}
+{% set color_class = {'error': 'danger', 'warning': 'warning', 'notice': 'info'} %}
+<div class="col-sm-10 col-sm-offset-1">
+  <h1 class="text-capitalize">Accessibility {{current_type}}s</h1>
+</div>
+<br />
+<div class="col-sm-10 col-sm-offset-1" style="margin-bottom: 30px;">
+  <div id='summary-toolbar' class="btn-group bars">
+    {% for type in ['error', 'warning', 'notice'] %}
+    <a  href="{{type}}s.html"
+        class="filterby-btn btn btn-secondary-outline text-capitalize {{'current' if type == current_type}}"
+        data-filterby='{{type}}'
+        aria-pressed="{{type == current_type}}">
+      {{type}}s
+      <span class="list-group-item-{{color_class[type]}} badge">{{ violation_counts[type] }}</span>
+      <span class="sr-only">Click to show {{type}}s.</span>
+    </a>
+    {% endfor %}
+  </div>
+
+  <table data-classes='table table-no-bordered'
+         data-toggle="table"
+         data-search="true">
+    <thead>
+      <tr>
+        <th data-field='type' data-sortable="true" data-width="10%">Type</th>
+        <th data-sortable="true" data-width="10%">WCAG</th>
+        <th data-sortable="true">Message</th>
+        <th data-sortable="true">HTML</th>
+        <th data-sortable="true" data-width="10%">Page Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for violation in grouped_violations %}
+        <tr>
+          <td class="{{ color_class[violation.type] }}">{{violation.type}}</td>
+          <td>
+          {% for ref in wcag_refs(violation.code) %}
+            <a href="https://www.w3.org/TR/WCAG20-TECHS/{{ ref }}.html">
+              <span class='sr-only'>Docs for </span>{{ ref }}
+            </a>
+          {% endfor %}
+          </td>
+          <td>{{violation.message}}</td>
+          <td>
+            {{ violation.selector | escape }}
+            <hr/>
+            {{ violation.context | escape }}
+          </td>
+          <td>
+            {{violation.pages|length}}
+          </td>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock content %}

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -22,6 +22,18 @@ def item(request):
 def test_render_html(item, tmpdir_factory):
     tmp_data_dir = Path(tmpdir_factory.mktemp('data'))
     pa11y_data = [{
+        "message": "Table cell has an invalid scope attribute.",
+        "code": "WCAG2AA.Principle2.Guideline2_4.2_4_2.H63.1",
+        "type": "error",
+        "context": "<th class=\"label\" scope=\"column\">Email</th>",
+        "selector": "#fake > th",
+    }, {
+        "message": "This hidden form field is labelled in some way.",
+        "code": "WCAG2AA.Principle2.Guideline2_4.2_4_2.F68.2",
+        "type": "warning",
+        "context": "<input type=\"hidden\" />",
+        "selector": "#fake > div",
+    }, {
         "message": "Check that the title element describes the document.",
         "code": "WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2",
         "type": "notice",
@@ -31,3 +43,6 @@ def test_render_html(item, tmpdir_factory):
     write_pa11y_results(item, pa11y_data, tmp_data_dir)
     render_html(tmp_data_dir, tmp_data_dir)
     assert os.path.isfile(os.path.join(tmp_data_dir, 'index.html'))
+    assert os.path.isfile(os.path.join(tmp_data_dir, 'errors.html'))
+    assert os.path.isfile(os.path.join(tmp_data_dir, 'warnings.html'))
+    assert os.path.isfile(os.path.join(tmp_data_dir, 'notices.html'))


### PR DESCRIPTION
### What
Simplify and deduplicate the list of sitewide violations. To get the list of unique violations, we index them by WCAG violation code + DOM selector. The index page now displays the new counts, which are significantly smaller and more actionable.

Add a new template to list these unique violations by category (errors, warnings, or notices) and display the number of pages each occurs for. These generated pages (`errors.html`, `warnings.html`, and `notices.html`) are now linked from the index page.

### Why
If a violation occurs for the same element on multiple pages (e.g. some chunk of the site header), we don't want to count it more than once. Grouping violations by code + selector allows us to:
- quickly identify and remediate problematic violations
- easily identify erroneous violations and flag them in the ignore rules
- accurately assess overall WCAG2AA conformance level

### Where
Generated pages are [viewable here](https://build.testeng.edx.org/job/edx-platform-accessibility-pr/30516/artifact/edx-platform/reports/pa11ycrawler/html/index.html). **Please note**: JS hosting is disabled on Jenkins so some of the table styling and functionality will not work, but you can get the general idea.

To run locally (and get the JS functionality), you can checkout the branch `arizzitano/pa11ycrawler-unique` and run the following:
```
paver pa11ycrawler --fasttest --skip-clean --fetch-course --with-html
```
then open `edx-platform/reports/pa11ycrawler/html/index.html` in a browser on your host machine.

### Screenshots
Changes to the index page numbers. Note that I removed the "total" count as it's not really an actionable number. Notices aren't necessarily actionable either (they are more like guidelines) but it's valuable to see them all in one place so we can easily pick out the ones that require ignore rules.
![image](https://cloud.githubusercontent.com/assets/491289/22761173/9c921162-ee27-11e6-882a-fe3575026bb0.png)

Generated errors page:
![image](https://cloud.githubusercontent.com/assets/491289/22761460/c75b37ec-ee28-11e6-926e-6059287d9574.png)

Warnings page:
![image](https://cloud.githubusercontent.com/assets/491289/22761472/d72d1dde-ee28-11e6-9f02-5fe3cde0812f.png)

Notices page:
![image](https://cloud.githubusercontent.com/assets/491289/22761484/ee675546-ee28-11e6-98b6-d2e27bdedf1e.png)

Design feedback is welcome!

/cc @jzoldak @benpatterson @cptvitamin (please feel free to add other folks who might be interested as well)