### PR TITLE
TE-2647 Switch from phantomjs to headless Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-sudo: false
+dist: trusty
+sudo: required
+addons:
+  chrome: stable
 language: python
 python:
   - '2.7'
   - '3.6'
+env:
+  - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
 install:
   - pip install --upgrade pip
   - pip install codecov

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: requirements
+.PHONY: clean clean-data clean-html develop install quality requirements requirements.js test
 
 requirements: requirements.js
 	pip install --quiet --upgrade -r requirements.txt --exists-action w
@@ -24,7 +24,7 @@ clean-html:
 
 test: clean
 	scrapy check edx
-	py.test --cov=./
+	pytest --cov=./
 
 quality: develop
 	pycodestyle pa11ycrawler

--- a/README.md
+++ b/README.md
@@ -13,9 +13,19 @@ JSON files, which can be transformed into a beautiful HTML report.
 Installation
 ============
 
-pa11ycrawler requires Python 2.7+ and Node.js installed. You must also install
-[phantomjs](http://phantomjs.org/), which [pa11y](http://pa11y.org/) uses
-in order to run accessibility tests on each page of a website.
+pa11ycrawler requires Python 2.7+ and Node.js 8+ installed.  You must also
+install Google Chrome, which the
+[Puppeteer](https://developers.google.com/web/tools/puppeteer/) library used
+by pa11ycralwer uses to run accessibility tests on each page of a website.
+You also need to set the following environment variables before installing NPM
+dependencies:
+
+* PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+* PUPPETEER_EXECUTABLE_PATH={path to Google Chrome binary}
+
+If these are not set, Puppeteer will download a separate copy of Chromium
+(but none of its dependencies, leaving it unusable in most Docker containers
+and headless servers).
 
 ```
 make install

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.7
 pytest-mock
-freezegun==0.3.7
+freezegun==0.3.10
 pycodestyle
 edx-lint
 # Enabling LogCapture for testing

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "pa11ycrawler",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "private": true,
   "dependencies": {
-    "pa11y": "4.0.1",
-    "pa11y-reporter-json-oldnode": "1.0.0"
+    "pa11y": "5.1.0"
   },
   "renovate": {
     "extends": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [pep8]
 max-line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '1.7.3'
+VERSION = '1.8.0'
 DESCRIPTION = 'A Scrapy spider for a11y auditing Open edX installations.'
 LONG_DESCRIPTION = """pa11ycrawler is a Scrapy spider that runs a Pa11y check
 on every page of an Open edX installation,


### PR DESCRIPTION
Upgrade pa11y to a version that uses headless Chrome instead of the no longer maintained phantomjs.  Also, deploy to PyPI automatically when release tags are pushed.