### PR TITLE
Pin scrapy to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ lxml<4.0
 path.py<9.0
 pyyaml<4.0
 requests<3.0
-scrapy
+scrapy==1.6.0
 urlobject<3.0
-Twisted
 pytest-cov>=2.4.0


### PR DESCRIPTION
Even though we're going to revamp the requirements soon for OEP-18, I think we should pin scrapy for now to ensure we don't start failing CI builds if a problematic version of scrapy gets pushed to pypi. I was debating doing this on my last PR, and since I decided I'll push a new release, I'd like to limit possible problems of running this on edx-platform.